### PR TITLE
url 생성시 미리보기 화면을 구현하라

### DIFF
--- a/src/icons/information-circle.tsx
+++ b/src/icons/information-circle.tsx
@@ -1,0 +1,16 @@
+export const InformationCircle = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="w-6 h-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+    />
+  </svg>
+);

--- a/src/pages/[linkHash].tsx
+++ b/src/pages/[linkHash].tsx
@@ -1,14 +1,10 @@
-import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { kv } from "@/modules/database";
-import { isUndefined, head, isArray, isString } from "lodash";
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import { kv } from '@/modules/database';
+import { isUndefined, head, isArray, isString } from 'lodash';
 
 const LinkHashPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { message } = props;
-  return (
-    <div>
-      {message}
-    </div>
-  );
+  return <div>{message}</div>;
 };
 
 const getFirstQueryParam = (data?: string | string[]): string => {
@@ -22,27 +18,28 @@ const getFirstQueryParam = (data?: string | string[]): string => {
     return data;
   }
   return 'INVALID';
-}
+};
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context;
   const { linkHash } = query;
   const firstLinkHash = getFirstQueryParam(linkHash);
+
   if (isUndefined(firstLinkHash)) {
     return {
       props: {
-        message: 'link not found'
-      }
+        message: 'link not found',
+      },
     };
   }
-  const targetLink = await kv.get(firstLinkHash);
+  const targetLink = (await kv.get(firstLinkHash)) ?? ' ';
   console.log(`DEBUG : TARGET_LINK : ${firstLinkHash} : ${targetLink}`);
   return {
     redirect: {
       permanent: false,
       destination: targetLink as string,
     },
-  }
-}
+  };
+};
 
 export default LinkHashPage;

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -2,6 +2,7 @@ import { IOS_PREFIX, AOS_PREFIX, TARGET_BASE_HOST } from '@/configs';
 import { useRef, useState } from 'react';
 import { chain, get, isEmpty } from 'lodash';
 import axios from 'axios';
+import { InformationCircle } from '../icons/information-circle';
 
 // AOS fallback location.href = 'https://play.google.com/store/apps/details?id=com.dbs.kurly.m2';
 interface FormData {
@@ -63,6 +64,10 @@ const CreateLinkPage = () => {
                 >
                   복사하기
                 </button>
+                <div className="flex">
+                  <InformationCircle />
+                  <span className="ml-3 text-rose-700"> main 페이지가 보일 시 주소를 다시 확인해주세요!</span>
+                </div>
               </div>
             ) : null}
             {typeof window !== 'undefined' && url ? (

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -1,6 +1,6 @@
 import { IOS_PREFIX, AOS_PREFIX, TARGET_BASE_HOST } from '@/configs';
-import { RefObject, useRef, useState } from 'react';
-import { chain, get, isEmpty, isNull } from 'lodash';
+import { useRef, useState } from 'react';
+import { chain, get, isEmpty } from 'lodash';
 import axios from 'axios';
 
 // AOS fallback location.href = 'https://play.google.com/store/apps/details?id=com.dbs.kurly.m2';
@@ -35,6 +35,15 @@ const CreateLinkPage = () => {
     const { data } = await axios.post('/api/v2/create', formData);
     setUrl(data?.result);
   };
+  const handleCopyClipBoard = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      alert('클립보드에 링크가 복사되었습니다.');
+    } catch (e) {
+      alert('복사에 실패하였습니다');
+    }
+  };
+
   return (
     <div className="md:container md:mx-auto p-4">
       {!isEmpty(url) ? <div>{url}</div> : null}
@@ -44,6 +53,23 @@ const CreateLinkPage = () => {
           <div className="border-b border-gray-900/10 pb-12">
             <h2 className="text-base font-semibold leading-7 text-gray-900">Personal Information</h2>
             <p className="mt-1 text-sm leading-6 text-gray-600">Use a permanent address where you can receive mail.</p>
+            {url ? (
+              <div className="my-5">
+                <span> 미리보기 url : {url} </span>
+                <button
+                  type="button"
+                  onClick={handleCopyClipBoard}
+                  className="rounded-md bg-purple-600 px-3 py-1 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                >
+                  복사하기
+                </button>
+              </div>
+            ) : null}
+            {typeof window !== 'undefined' && url ? (
+              <iframe src={url} width="100%" height="500px">
+                <p>사용 중인 브라우저는 iframe을 지원하지 않습니다.</p>
+              </iframe>
+            ) : null}
             <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
               <div className="col-span-full">
                 <label htmlFor="webAddr" className="block text-sm font-medium leading-6 text-gray-900">


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX196OZloAGhr4iYWYJzKck9NlhLRDoDORE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=g72h88y)

구현 내용
- url 생성 버튼 클릭시 미리보기 화면 추가
- url 복사하기 버튼 추가

권한이 없어서 fork해서 pr 생성했습니다.
주소를 고정하기 전에 어디어디 가능한지 모르기도 해서 일단 미리보기가 있으면 도움이 될 것 같았습니다.
user-agent를 활용하거나 해서 MW도 하고 싶었는데 보안상의 이유로 실패했습니당...

<img width="1584" alt="스크린샷 2023-08-06 오후 6 23 14" src="https://github.com/seungjaey/linker-prototype/assets/98067293/6bfbf8f6-0db9-432b-804b-0ca3e3c2f8da">
